### PR TITLE
Specify a BeautifulSoup parser

### DIFF
--- a/bin/wa
+++ b/bin/wa
@@ -30,7 +30,7 @@ def main():
     if not response.ok:
         raise Exception('HTTP request failed')
 
-    soup = BeautifulSoup(response.text)
+    soup = BeautifulSoup(response.text, "lxml")
 
     if soup.queryresult.attrs['error'] == 'true':
         raise Exception('WolframAlpha error %s: %s'


### PR DESCRIPTION
A warning is displayed when using BeautifulSoup >4.4.0 without specifying a parser.
https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/NEWS.txt#L23
https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/bs4/__init__.py#L80